### PR TITLE
Add SwiftUI WebP converter skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "WebpApp",
+    platforms: [
+        .macOS(.v11)
+    ],
+    targets: [
+        .executableTarget(
+            name: "WebpApp",
+            path: "Sources",
+            swiftSettings: [
+                .interoperabilityMode(.C)
+            ]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # webp-osx
-A OSX-Tool to convert any image file into webp
+
+A macOS application to convert common image formats to WebP. The UI is built with SwiftUI and allows drag-and-drop of files or folders. Users can specify the output size, keep the aspect ratio, and choose a custom name for the resulting images.
+
+## Requirements
+
+- macOS 11 or newer
+- Xcode with Swift 5.7 or newer
+
+## Building
+
+Open the project directory in Xcode and build the `WebpApp` executable target. The application uses the native WebP support provided by `ImageIO` on macOS.
+
+## Usage
+
+Drag images or folders onto the application window, adjust the width/height settings, and press **Convert**. The converted images will be saved next to the originals with the provided output name.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var inputItems: [URL] = []
+    @State private var width: String = ""
+    @State private var height: String = ""
+    @State private var keepAspect: Bool = true
+    @State private var useLongSide: Bool = true
+    @State private var outputName: String = "output"
+    @State private var isConverting: Bool = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        VStack(spacing: 20) {
+            DropAreaView(items: $inputItems)
+                .frame(height: 150)
+                .background(Color(NSColor.windowBackgroundColor))
+                .cornerRadius(8)
+                .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray))
+
+            HStack {
+                TextField("Width", text: $width)
+                    .frame(width: 80)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                TextField("Height", text: $height)
+                    .frame(width: 80)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                Toggle("Keep Aspect", isOn: $keepAspect)
+                Picker("Side", selection: $useLongSide) {
+                    Text("Long Side").tag(true)
+                    Text("Short Side").tag(false)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+            }
+
+            TextField("Output Name", text: $outputName)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .frame(maxWidth: 300)
+
+            if let message = errorMessage {
+                Text(message)
+                    .foregroundColor(Color(hex: "#FF7F50"))
+            }
+
+            Button(action: convert) {
+                if isConverting {
+                    ProgressView()
+                } else {
+                    Text("Convert")
+                        .padding()
+                        .background(Color(hex: "#EEF19B"))
+                        .cornerRadius(8)
+                }
+            }
+            .disabled(isConverting || inputItems.isEmpty)
+        }
+        .padding()
+        .frame(minWidth: 500, minHeight: 400)
+    }
+
+    private func convert() {
+        isConverting = true
+        errorMessage = nil
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                try WebpConverter.convert(items: inputItems,
+                                          width: Int(width),
+                                          height: Int(height),
+                                          keepAspect: keepAspect,
+                                          useLongSide: useLongSide,
+                                          outputName: outputName)
+            } catch {
+                DispatchQueue.main.async {
+                    errorMessage = error.localizedDescription
+                }
+            }
+            DispatchQueue.main.async {
+                isConverting = false
+            }
+        }
+    }
+}
+
+struct DropAreaView: NSViewRepresentable {
+    @Binding var items: [URL]
+
+    func makeNSView(context: Context) -> DropView {
+        let view = DropView()
+        view.onURLsDropped = { urls in
+            items = urls
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: DropView, context: Context) {}
+}
+
+class DropView: NSView {
+    var onURLsDropped: (([URL]) -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        registerForDraggedTypes([.fileURL])
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        registerForDraggedTypes([.fileURL])
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        return .copy
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let urls = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] else {
+            return false
+        }
+        onURLsDropped?(urls)
+        return true
+    }
+}
+
+extension Color {
+    init(hex: String) {
+        let scanner = Scanner(string: hex)
+        _ = scanner.scanString("#")
+        var rgb: UInt64 = 0
+        scanner.scanHexInt64(&rgb)
+        let r = Double((rgb >> 16) & 0xFF) / 255.0
+        let g = Double((rgb >> 8) & 0xFF) / 255.0
+        let b = Double(rgb & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Sources/WebpApp.swift
+++ b/Sources/WebpApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct WebpApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Sources/WebpConverter.swift
+++ b/Sources/WebpConverter.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ImageIO
+import AVFoundation
 
 enum WebpConverter {
     static func convert(items: [URL],

--- a/Sources/WebpConverter.swift
+++ b/Sources/WebpConverter.swift
@@ -1,0 +1,94 @@
+import AppKit
+import ImageIO
+
+enum WebpConverter {
+    static func convert(items: [URL],
+                        width: Int?,
+                        height: Int?,
+                        keepAspect: Bool,
+                        useLongSide: Bool,
+                        outputName: String) throws {
+        let fileManager = FileManager.default
+        for (index, url) in items.enumerated() {
+            let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            if isDir {
+                let contents = try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+                try convert(items: contents, width: width, height: height, keepAspect: keepAspect, useLongSide: useLongSide, outputName: outputName)
+                continue
+            }
+
+            guard let image = NSImage(contentsOf: url) else { continue }
+            let targetSize = resizedSize(for: image.size, width: width, height: height, keepAspect: keepAspect, useLongSide: useLongSide)
+            let resizedImage = image.resized(to: targetSize)
+            let destURL = url.deletingLastPathComponent()
+                .appendingPathComponent("\(outputName)_\(index).webp")
+            try saveWebP(image: resizedImage, to: destURL)
+        }
+    }
+
+    private static func resizedSize(for size: NSSize,
+                                    width: Int?,
+                                    height: Int?,
+                                    keepAspect: Bool,
+                                    useLongSide: Bool) -> NSSize {
+        var w = CGFloat(width ?? Int(size.width))
+        var h = CGFloat(height ?? Int(size.height))
+
+        if keepAspect {
+            if width != nil && height == nil {
+                let ratio = size.height / size.width
+                h = w * ratio
+            } else if height != nil && width == nil {
+                let ratio = size.width / size.height
+                w = h * ratio
+            } else if width == nil && height == nil {
+                w = size.width
+                h = size.height
+            }
+        } else if width == nil || height == nil {
+            if useLongSide {
+                let long = max(size.width, size.height)
+                let short = min(size.width, size.height)
+                if width != nil {
+                    let ratio = short / long
+                    h = CGFloat(width!) * ratio
+                } else if height != nil {
+                    let ratio = short / long
+                    w = CGFloat(height!) * ratio
+                }
+            } else {
+                if width != nil {
+                    h = CGFloat(width!)
+                } else if height != nil {
+                    w = CGFloat(height!)
+                }
+            }
+        }
+        return NSSize(width: w, height: h)
+    }
+
+    private static func saveWebP(image: NSImage, to url: URL) throws {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            throw NSError(domain: "WebpConverter", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unable to create CGImage"])
+        }
+        guard let dest = CGImageDestinationCreateWithURL(url as CFURL, AVFileType.webp as CFString, 1, nil) else {
+            throw NSError(domain: "WebpConverter", code: 2, userInfo: [NSLocalizedDescriptionKey: "Unable to create destination"])
+        }
+        CGImageDestinationAddImage(dest, cgImage, nil)
+        if !CGImageDestinationFinalize(dest) {
+            throw NSError(domain: "WebpConverter", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to finalize WebP"])
+        }
+    }
+}
+
+extension NSImage {
+    func resized(to size: NSSize) -> NSImage {
+        let img = NSImage(size: size)
+        img.lockFocus()
+        defer { img.unlockFocus() }
+        let ctx = NSGraphicsContext.current
+        ctx?.imageInterpolation = .high
+        draw(in: NSRect(origin: .zero, size: size), from: .zero, operation: .copy, fraction: 1)
+        return img
+    }
+}


### PR DESCRIPTION
## Summary
- set up Swift Package skeleton for macOS 11+
- create SwiftUI app with drag & drop, size options, and convert button
- add WebP conversion helper
- document build and usage instructions

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6878904f5b2c833398b1b0db610c31c9